### PR TITLE
Integrating roamjs-finance with RoamJS

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,8 +11,8 @@ jobs:
       - name: Build
         run: npm run build
       - name: RoamJS Publish
-        uses: dvargas92495/roamjs-publish@0.1.0
+        uses: dvargas92495/roamjs-publish@0.1.2
         with:
           token: ${{ secrets.ROAMJS_DEVELOPER_TOKEN }}
           source: public
-          dest: finance-demo
+          path: finance-demo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,18 @@
+on: [push]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    name: Deploy
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install
+        run: npm install
+      - name: Build
+        run: npm run build
+      - name: RoamJS Publish
+        uses: dvargas92495/roamjs-publish@0.1.0
+        with:
+          token: ${{ secrets.ROAMJS_DEVELOPER_TOKEN }}
+          source: public
+          dest: finance-demo

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ jobs:
       - name: Build
         run: npm run build
       - name: RoamJS Publish
-        uses: dvargas92495/roamjs-publish@0.1.2
+        uses: dvargas92495/roamjs-publish@0.1.3
         with:
           token: ${{ secrets.ROAMJS_DEVELOPER_TOKEN }}
           source: public

--- a/src/components/crypto-price-table.ts
+++ b/src/components/crypto-price-table.ts
@@ -4,7 +4,17 @@ import {
   addChildToElem
 } from '../common'
 
-
+window.roamFinance.crypto = {
+  tickers: [
+    'BTC', 
+    'ETH', 
+    'LTC',
+    'BAT',
+    'CEL',
+    'NEO',
+  ],
+  currency: 'eur'
+}
 
 const months = new Set(['January', 'Jan', 
                        'February', 'Feb', 


### PR DESCRIPTION
Hey Andrey!

Long term, I want RoamJS to be a place where developers could publish their extensions without having to merge their code to the repo. This decentralization I think is best for RoamJS to scale.

This is the first step of being able to publish extensions to RoamJS - the extensions themselves. There is a GitHub action publicly available now that allows other Roam developers to automatically publish their extensions to RoamJS every time they make changes to it. This PR demonstrates a use case for this.

The next step is I want to pull the README of this repo and use it as the extension page content. Is the README ready to share?

From my forked repo, the extensions were published under `https://roamjs.com/finance-demo/crypto-price-table.js` and `https://roamjs.com/finance-demo/stock-price-table.js`. Here's proof of it working:

![image](https://user-images.githubusercontent.com/7143571/113198252-b6a22880-9233-11eb-98ae-ca145daf3f54.png)
